### PR TITLE
Feat: Rename cli commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@
 # Usage:
 #   make test       - Run the test suite
 #   make install    - Install symlish globally (may require sudo)
-#   make upgrade    - Alias for install; safe to run over an existing install
 #   make uninstall  - Remove global installation
 #   make clean      - Remove generated files
 #
@@ -13,8 +12,6 @@
 #
 # For global installation you may need sudo:
 #   sudo make install
-
-SHELL := /bin/bash
 
 # Installation paths
 PREFIX      ?= /usr/local
@@ -33,18 +30,51 @@ PROVE       := prove
 CRITIC      := perlcritic
 TIDY        := perltidy
 
-# Colors for output
+# Colours for output
 RED    := \033[0;31m
 GREEN  := \033[0;32m
 YELLOW := \033[0;33m
 BLUE   := \033[0;34m
-NC     := \033[0m  # No Color
+NC     := \033[0m  # No Colour
 
-.PHONY: all test test-verbose test-file lint lint-strict tidy tidy-check \
-        install upgrade uninstall install-user uninstall-user run clean help
+.PHONY: help test test-verbose test-file lint lint-strict tidy tidy-check \
+        install uninstall install-user uninstall-user clean
 
-# Default target
-all: test
+#=============================================================================
+# Help
+#=============================================================================
+
+## Show this help message (default target)
+help:
+	@echo ""
+	@echo "Symlish Makefile"
+	@echo "================"
+	@echo ""
+	@echo "Usage: make [target]"
+	@echo ""
+	@echo "Targets:"
+	@echo "  test          Run the test suite"
+	@echo "  test-verbose  Run tests with verbose output"
+	@echo "  test-file     Run specific test (FILE=t/00-config.t)"
+	@echo ""
+	@echo "  lint          Run Perl::Critic (severity 4)  [requires Perl::Critic]"
+	@echo "  lint-strict   Run Perl::Critic (severity 3)  [requires Perl::Critic]"
+	@echo "  tidy          Format code with Perl::Tidy    [requires Perl::Tidy]"
+	@echo "  tidy-check    Check formatting without changes"
+	@echo ""
+	@echo "  install       Install globally to $(PREFIX) (may need sudo)"
+	@echo "  uninstall     Remove global installation"
+	@echo "  install-user  Install to ~/.local (no sudo)"
+	@echo "  uninstall-user Remove user installation"
+	@echo ""
+	@echo "  clean         Remove generated files"
+	@echo "  help          Show this help message"
+	@echo ""
+	@echo "Examples:"
+	@echo "  make test         # Run all tests"
+	@echo "  sudo make install # Install globally"
+	@echo "  make install-user # Install to ~/.local"
+	@echo ""
 
 #=============================================================================
 # Testing
@@ -128,9 +158,6 @@ install: test
 	@echo -e "$(GREEN)==> Installation complete!$(NC)"
 	@echo -e "    Run 'symlish help' to get started"
 
-## Upgrade an existing installation (alias for install)
-upgrade: install
-
 ## Remove global installation
 uninstall:
 	@echo -e "$(BLUE)==> Uninstalling symlish...$(NC)"
@@ -150,10 +177,6 @@ uninstall-user:
 # Development
 #=============================================================================
 
-## Run the application locally (usage: make run ARGS="link ~/dotfiles --dry-run")
-run:
-	@$(PERL) -Ilib $(SRC_BIN) $(ARGS)
-
 ## Clean generated files
 clean:
 	@echo -e "$(BLUE)==> Cleaning...$(NC)"
@@ -161,43 +184,3 @@ clean:
 	@rm -f $(SRC_BIN).bak
 	@rm -rf cover_db/
 	@echo -e "$(GREEN)==> Clean complete$(NC)"
-
-#=============================================================================
-# Help
-#=============================================================================
-
-## Show this help message
-help:
-	@echo ""
-	@echo "Symlish Makefile"
-	@echo "================"
-	@echo ""
-	@echo "Usage: make [target]"
-	@echo ""
-	@echo "Targets:"
-	@echo "  test          Run the test suite"
-	@echo "  test-verbose  Run tests with verbose output"
-	@echo "  test-file     Run specific test (FILE=t/00-config.t)"
-	@echo ""
-	@echo "  lint          Run Perl::Critic (severity 4)  [requires Perl::Critic]"
-	@echo "  lint-strict   Run Perl::Critic (severity 3)  [requires Perl::Critic]"
-	@echo "  tidy          Format code with Perl::Tidy    [requires Perl::Tidy]"
-	@echo "  tidy-check    Check formatting without changes"
-	@echo ""
-	@echo "  install       Install globally to $(PREFIX) (may need sudo)"
-	@echo "  upgrade       Upgrade an existing installation (alias for install)"
-	@echo "  uninstall     Remove global installation"
-	@echo "  install-user  Install to ~/.local (no sudo)"
-	@echo "  uninstall-user Remove user installation"
-	@echo ""
-	@echo "  run           Run locally (ARGS=\"link ~/dotfiles\")"
-	@echo "  clean         Remove generated files"
-	@echo "  help          Show this help message"
-	@echo ""
-	@echo "Examples:"
-	@echo "  make test                          # Run all tests"
-	@echo "  make run ARGS=\"status ~/dotfiles\" # Test locally"
-	@echo "  sudo make install                  # Install globally"
-	@echo "  sudo make upgrade                  # Upgrade existing install"
-	@echo "  make install-user                  # Install to ~/.local"
-	@echo ""

--- a/bin/Main.pl
+++ b/bin/Main.pl
@@ -10,15 +10,15 @@ use Symlish::Options    qw(parse_command parse_directory parse_options);
 use Symlish::Config     qw(load_config);
 use Symlish::Targets    qw(build_targets filter_targets);
 use Symlish::Logger     qw(info);
-use Symlish::Commands   qw(do_link do_unlink do_status);
+use Symlish::Commands   qw(do_apply do_clean do_status);
 
 
 # main() - Entry point for the symlish CLI application.
 # Parses command-line arguments, loads configuration, builds targets,
-# and dispatches to the appropriate command handler (link/unlink/status).
+# and dispatches to the appropriate command handler (apply/clean/status).
 sub main {
     # Parse the command and directory
-    my $command     = parse_command   (shift @ARGV, qw(link unlink status));
+    my $command     = parse_command   (shift @ARGV, qw(apply clean status));
     my $directory   = parse_directory (shift @ARGV);
     my %options     = parse_options   (\@ARGV);
 
@@ -44,8 +44,8 @@ sub main {
         }
 
         # Dispatch command
-        if    ($command eq 'link')   { do_link  ($target, \%options) }
-        elsif ($command eq 'unlink') { do_unlink($target, \%options) }
+        if    ($command eq 'apply')  { do_apply ($target, \%options) }
+        elsif ($command eq 'clean')  { do_clean ($target, \%options) }
         elsif ($command eq 'status') { do_status($target)              }
     }
 

--- a/lib/Symlish/Commands.pm
+++ b/lib/Symlish/Commands.pm
@@ -4,17 +4,18 @@ use strict;
 use warnings;
 
 use Exporter 'import';
-our @EXPORT_OK = qw(do_link do_unlink do_status);
+our @EXPORT_OK = qw(do_apply do_clean do_status);
 
 use Symlish::Logger qw(info trace);
 
-# do_link($target, $options_ref) - Creates symlinks for a target.
-# Handles: skipping empty sources, conflict detection, backup creation.
-# In dry-run mode, only prints what would be done.
+# do_apply($target, $options_ref) - Backend for the `apply` command:
+# creates symlinks for a target. Handles skipping empty sources, conflict
+# detection, and backup creation. In dry-run mode, only prints what would
+# be done.
 # Params:
 #   $target      - LinkTarget object
 #   $options_ref - Hash ref with 'dry-run' flag
-sub do_link {
+sub do_apply {
     my ($target, $options_ref) = @_;
 
     my $dry_run = $options_ref->{'dry-run'};
@@ -22,14 +23,14 @@ sub do_link {
 
     for my $item ($target->items) {
 
+        # If already linked, skip.
+        next if $item->is_here;
+
         # Skip empty?
         if ($target->ignore_empty && $item->is_source_empty) {
             push @yellow, "Skipping empty: ${ \$item->source }";
             next
         }
-
-        # If already linked, skip
-        next if $item->is_here;
 
         # Conflict: a symlink exists but points elsewhere
         if ($item->is_symlink) {
@@ -72,13 +73,14 @@ sub do_link {
     info ($_, 'cyan', 2)    for @cyan;
 }
 
-# do_unlink($target, $options_ref) - Removes symlinks and restores backups.
-# Only removes symlinks that point to our source files.
-# In dry-run mode, only prints what would be done.
+# do_clean($target, $options_ref) - Backend for the `clean` command:
+# removes symlinks and restores backups. Only removes symlinks that 
+# point to our source files. In dry-run mode, only prints what would be
+# done.
 # Params:
 #   $target      - LinkTarget object
 #   $options_ref - Hash ref with 'dry-run' flag
-sub do_unlink {
+sub do_clean {
     my ($target, $options_ref) = @_;
 
     my $dry_run = $options_ref->{'dry-run'};
@@ -117,8 +119,9 @@ sub do_unlink {
     info ($_, 'cyan', 2)    for @cyan;
 }
 
-# do_status($target) - Displays current symlink status for a target.
-# Shows: backup existence, link status (linked/not linked/wrong target).
+# do_status($target) - Backend for the `status` command:
+# displays current symlink status for a target showing: backup existence, 
+# link status (linked/not linked/wrong target).
 # Params:
 #   $target - LinkTarget object
 sub do_status {

--- a/lib/Symlish/Options.pm
+++ b/lib/Symlish/Options.pm
@@ -19,27 +19,27 @@ my $USAGE = <<'USAGE';
 Usage: symlish <command> <directory> [options]
 
 Commands:
-    link      Create symlinks from dotfiles to system locations
-    unlink    Remove symlinks and restore backups
+    apply     Create symlinks from dotfiles to system locations
+    clean     Remove symlinks and restore backups
     status    Show current symlink status
     help      Display this help message
     version   Show version number
 
 Options:
     --dry-run           Simulate without making changes
-    --ignore  x,y,z     Comma-separated list of targets to skip
+    --ignore  x,y,z     Comma-separated list of targets to skip (mutually exclusive with --only)
     --only    x,y,z     Process only these targets (mutually exclusive with --ignore)
     --verbose, -v       Enable verbose logging
 
 Examples:
     symlish status ~/dotfiles
-    symlish link ~/dotfiles --dry-run
-    symlish unlink ~/dotfiles --only git,bash
+    symlish apply ~/dotfiles --dry-run
+    symlish clean ~/dotfiles --only git,bash
 USAGE
 
 # parse_command($command, @supported) - Validates the command argument.
 # Params:
-#   $command   - The command string from CLI (e.g., 'link', 'unlink')
+#   $command   - The command string from CLI (e.g., 'apply', 'clean')
 #   @supported - List of valid command names
 # Returns: The validated command string
 # Dies: If command is invalid, or help or version is requested (exits 0 for help and version)

--- a/t/01-options.t
+++ b/t/01-options.t
@@ -22,12 +22,12 @@ use SymlishTest qw(capture);
 # Test: parse_command - valid commands
 #=============================================================================
 subtest 'parse_command with valid commands' => sub {
-    my @supported = qw(link unlink status);
+    my @supported = qw(apply clean status);
 
-    is(parse_command('link', @supported), 'link', 
-        'Accepts link command');
-    is(parse_command('unlink', @supported), 'unlink', 
-        'Accepts unlink command');
+    is(parse_command('apply', @supported), 'apply', 
+        'Accepts apply command');
+    is(parse_command('clean', @supported), 'clean', 
+        'Accepts clean command');
     is(parse_command('status', @supported), 'status', 
         'Accepts status command');
 };
@@ -36,7 +36,7 @@ subtest 'parse_command with valid commands' => sub {
 # Test: parse_command - invalid commands
 #=============================================================================
 subtest 'parse_command with invalid command' => sub {
-    my @supported = qw(link unlink status);
+    my @supported = qw(apply clean status);
     
     eval { parse_command('invalid', @supported) };
     like($@, qr/Unknown command/, 'Dies on unknown command');

--- a/t/05-commands.t
+++ b/t/05-commands.t
@@ -15,22 +15,11 @@ use File::Path qw(make_path remove_tree);
 
 use FindBin qw($RealBin);
 use lib "$RealBin/../lib";
+use lib "$RealBin/lib";
 
 use Symlish::LinkTarget;
-use Symlish::Commands qw(do_link do_unlink do_status);
-
-# Capture STDOUT from a code block using only core modules.
-sub _capture {
-    my ($code) = @_;
-    my $output = '';
-    open(my $fh, '>', \$output) or die "Cannot create capture handle: $!";
-    my $old = select($fh);
-    eval { $code->() };
-    my $err = $@;
-    select($old);
-    die $err if $err;
-    return $output;
-}
+use Symlish::Commands qw(do_apply do_clean do_status);
+use SymlishTest qw(capture);
 
 #=============================================================================
 # Setup: Create a mock dotfiles structure
@@ -58,9 +47,9 @@ sub setup_mock_dotfiles {
 }
 
 #=============================================================================
-# Test: do_link creates symlinks
+# Test: do_apply creates symlinks
 #=============================================================================
-subtest 'do_link creates symlinks' => sub {
+subtest 'do_apply creates symlinks' => sub {
     my ($root, $dotfiles, $home) = setup_mock_dotfiles();
     
     my $target = Symlish::LinkTarget->new(
@@ -75,8 +64,8 @@ subtest 'do_link creates symlinks' => sub {
     my $options = { 'dry-run' => 0 };
     
     # Capture output
-    my $stdout = _capture(sub {
-        do_link($target, $options);
+    my $stdout = capture(sub {
+        do_apply($target, $options);
     });
     
     # Check symlinks were created
@@ -91,9 +80,9 @@ subtest 'do_link creates symlinks' => sub {
 };
 
 #=============================================================================
-# Test: do_link dry-run mode
+# Test: do_apply dry-run mode
 #=============================================================================
-subtest 'do_link dry-run mode' => sub {
+subtest 'do_apply dry-run mode' => sub {
     my ($root, $dotfiles, $home) = setup_mock_dotfiles();
     
     my $target = Symlish::LinkTarget->new(
@@ -108,8 +97,8 @@ subtest 'do_link dry-run mode' => sub {
     my $options = { 'dry-run' => 1 };
     
     # Capture output
-    my $stdout = _capture(sub {
-        do_link($target, $options);
+    my $stdout = capture(sub {
+        do_apply($target, $options);
     });
     
     # Check symlinks were NOT created
@@ -121,9 +110,9 @@ subtest 'do_link dry-run mode' => sub {
 };
 
 #=============================================================================
-# Test: do_link creates backup of existing files
+# Test: do_apply creates backup of existing files
 #=============================================================================
-subtest 'do_link creates backup' => sub {
+subtest 'do_apply creates backup' => sub {
     my ($root, $dotfiles, $home) = setup_mock_dotfiles();
     
     # Create existing .bashrc in home
@@ -141,7 +130,7 @@ subtest 'do_link creates backup' => sub {
     
     my $options = { 'dry-run' => 0 };
     
-    _capture(sub { do_link($target, $options) });
+    capture(sub { do_apply($target, $options) });
     
     # Check backup was created
     my $backup = "$existing_bashrc.bak";
@@ -153,9 +142,9 @@ subtest 'do_link creates backup' => sub {
 };
 
 #=============================================================================
-# Test: do_link skips empty files with ignore-empty
+# Test: do_apply skips empty files with ignore-empty
 #=============================================================================
-subtest 'do_link skips empty files' => sub {
+subtest 'do_apply skips empty files' => sub {
     my ($root, $dotfiles, $home) = setup_mock_dotfiles();
     
     my $target = Symlish::LinkTarget->new(
@@ -170,7 +159,7 @@ subtest 'do_link skips empty files' => sub {
     
     my $options = { 'dry-run' => 0 };
     
-    my $stdout = _capture(sub { do_link($target, $options) });
+    my $stdout = capture(sub { do_apply($target, $options) });
     
     # empty.txt should be skipped
     my $empty_link = File::Spec->catfile($home, 'empty.txt');
@@ -179,9 +168,9 @@ subtest 'do_link skips empty files' => sub {
 };
 
 #=============================================================================
-# Test: do_unlink removes symlinks
+# Test: do_clean removes symlinks
 #=============================================================================
-subtest 'do_unlink removes symlinks' => sub {
+subtest 'do_clean removes symlinks' => sub {
     my ($root, $dotfiles, $home) = setup_mock_dotfiles();
     
     my $target = Symlish::LinkTarget->new(
@@ -196,21 +185,21 @@ subtest 'do_unlink removes symlinks' => sub {
     my $options = { 'dry-run' => 0 };
     
     # First, create the links
-    _capture(sub { do_link($target, $options) });
+    capture(sub { do_apply($target, $options) });
     
     my $bashrc_link = File::Spec->catfile($home, '.bashrc');
-    ok(-l $bashrc_link, 'Symlink exists before unlink');
+    ok(-l $bashrc_link, 'Symlink exists before clean');
     
-    # Now unlink
-    _capture(sub { do_unlink($target, $options) });
+    # Now clean
+    capture(sub { do_clean($target, $options) });
     
-    ok(!-e $bashrc_link, 'Symlink removed after unlink');
+    ok(!-e $bashrc_link, 'Symlink removed after clean');
 };
 
 #=============================================================================
-# Test: do_unlink restores backups
+# Test: do_clean restores backups
 #=============================================================================
-subtest 'do_unlink restores backups' => sub {
+subtest 'do_clean restores backups' => sub {
     my ($root, $dotfiles, $home) = setup_mock_dotfiles();
     
     # Create existing .bashrc
@@ -228,12 +217,12 @@ subtest 'do_unlink restores backups' => sub {
     
     my $options = { 'dry-run' => 0 };
     
-    # Link (creates backup)
-    _capture(sub { do_link($target, $options) });
+    # Apply (creates backup)
+    capture(sub { do_apply($target, $options) });
     ok(-e "$bashrc.bak", 'Backup created');
     
-    # Unlink (restores backup)
-    _capture(sub { do_unlink($target, $options) });
+    # Clean (restores backup)
+    capture(sub { do_clean($target, $options) });
     
     ok(-e $bashrc, '.bashrc restored');
     ok(!-l $bashrc, '.bashrc is a regular file, not symlink');
@@ -242,9 +231,9 @@ subtest 'do_unlink restores backups' => sub {
 };
 
 #=============================================================================
-# Test: do_unlink dry-run mode
+# Test: do_clean dry-run mode
 #=============================================================================
-subtest 'do_unlink dry-run mode' => sub {
+subtest 'do_clean dry-run mode' => sub {
     my ($root, $dotfiles, $home) = setup_mock_dotfiles();
     
     my $target = Symlish::LinkTarget->new(
@@ -257,13 +246,13 @@ subtest 'do_unlink dry-run mode' => sub {
     );
     
     # Create links first
-    _capture(sub { do_link($target, { 'dry-run' => 0 }) });
+    capture(sub { do_apply($target, { 'dry-run' => 0 }) });
     
     my $bashrc_link = File::Spec->catfile($home, '.bashrc');
     ok(-l $bashrc_link, 'Symlink exists');
     
-    # Dry-run unlink
-    my $stdout = _capture(sub { do_unlink($target, { 'dry-run' => 1 }) });
+    # Dry-run clean
+    my $stdout = capture(sub { do_clean($target, { 'dry-run' => 1 }) });
     
     ok(-l $bashrc_link, 'Symlink still exists after dry-run');
     like($stdout, qr/Would unlink/, 'Dry-run output shows "Would unlink"');
@@ -285,21 +274,21 @@ subtest 'do_status shows status' => sub {
     );
     
     # Status before linking
-    my $stdout1 = _capture(sub { do_status($target) });
+    my $stdout1 = capture(sub { do_status($target) });
     like($stdout1, qr/not linked/, 'Shows "not linked" before linking');
     
-    # Create links
-    _capture(sub { do_link($target, { 'dry-run' => 0 }) });
+    # Apply
+    capture(sub { do_apply($target, { 'dry-run' => 0 }) });
     
     # Status after linking
-    my $stdout2 = _capture(sub { do_status($target) });
+    my $stdout2 = capture(sub { do_status($target) });
     like($stdout2, qr/->/, 'Shows arrow indicating symlink');
 };
 
 #=============================================================================
-# Test: do_link skips if already linked
+# Test: do_apply skips if already linked
 #=============================================================================
-subtest 'do_link skips already linked' => sub {
+subtest 'do_apply skips already linked' => sub {
     my ($root, $dotfiles, $home) = setup_mock_dotfiles();
     
     my $target = Symlish::LinkTarget->new(
@@ -313,9 +302,9 @@ subtest 'do_link skips already linked' => sub {
     
     my $options = { 'dry-run' => 0 };
     
-    # Link twice
-    _capture(sub { do_link($target, $options) });
-    my $stdout2 = _capture(sub { do_link($target, $options) });
+    # Apply twice
+    capture(sub { do_apply($target, $options) });
+    my $stdout2 = capture(sub { do_apply($target, $options) });
     
     # Second run should be quiet (links already exist)
     my $bashrc_link = File::Spec->catfile($home, '.bashrc');

--- a/t/07-integration.t
+++ b/t/07-integration.t
@@ -14,23 +14,12 @@ use File::Path qw(make_path);
 
 use FindBin qw($RealBin);
 use lib "$RealBin/../lib";
+use lib "$RealBin/lib";
 
 use Symlish::Config qw(load_config);
 use Symlish::Targets qw(build_targets filter_targets);
-use Symlish::Commands qw(do_link do_unlink do_status);
-
-# Capture STDOUT from a code block using only core modules.
-sub _capture {
-    my ($code) = @_;
-    my $output = '';
-    open(my $fh, '>', \$output) or die "Cannot create capture handle: $!";
-    my $old = select($fh);
-    eval { $code->() };
-    my $err = $@;
-    select($old);
-    die $err if $err;
-    return $output;
-}
+use Symlish::Commands qw(do_apply do_clean do_status);
+use SymlishTest qw(capture);
 
 #=============================================================================
 # Setup: Create a complete mock dotfiles repository
@@ -139,9 +128,9 @@ INI
 }
 
 #=============================================================================
-# Test: Full link workflow
+# Test: Full apply workflow
 #=============================================================================
-subtest 'Full link workflow' => sub {
+subtest 'Full apply workflow' => sub {
     my $mock = create_mock_dotfiles_repo();
     
     # Load config
@@ -152,12 +141,12 @@ subtest 'Full link workflow' => sub {
     my @targets = build_targets($config);
     ok(scalar(@targets) >= 4, 'Multiple targets built');
     
-    # Link all targets
+    # Apply all targets
     for my $target (@targets) {
         next unless $target->is_valid;
         next if $target->ignore;
         
-        _capture(sub { do_link($target, { 'dry-run' => 0 }) });
+        capture(sub { do_apply($target, { 'dry-run' => 0 }) });
     }
     
     # Verify bash symlinks
@@ -181,32 +170,32 @@ subtest 'Full link workflow' => sub {
 };
 
 #=============================================================================
-# Test: Full unlink workflow
+# Test: Full clean workflow
 #=============================================================================
-subtest 'Full unlink workflow' => sub {
+subtest 'Full clean workflow' => sub {
     my $mock = create_mock_dotfiles_repo();
     
     my $config = load_config($mock->{dotfiles});
     my @targets = build_targets($config);
     
-    # Link first
+    # Apply first
     for my $target (@targets) {
         next unless $target->is_valid;
         next if $target->ignore;
-        _capture(sub { do_link($target, { 'dry-run' => 0 }) });
+        capture(sub { do_apply($target, { 'dry-run' => 0 }) });
     }
     
     my $bashrc = File::Spec->catfile($mock->{home}, '.bashrc');
-    ok(-l $bashrc, '.bashrc exists before unlink');
+    ok(-l $bashrc, '.bashrc exists before clean');
     
-    # Unlink
+    # Clean
     for my $target (@targets) {
         next unless $target->is_valid;
         next if $target->ignore;
-        _capture(sub { do_unlink($target, { 'dry-run' => 0 }) });
+        capture(sub { do_clean($target, { 'dry-run' => 0 }) });
     }
     
-    ok(!-e $bashrc, '.bashrc removed after unlink');
+    ok(!-e $bashrc, '.bashrc removed after clean');
 };
 
 #=============================================================================
@@ -222,15 +211,15 @@ subtest 'Status reporting' => sub {
     my ($bash_target) = grep { $_->key eq 'bash' } @targets;
     ok($bash_target, 'Found bash target');
     
-    # Status before linking
-    my $before = _capture(sub { do_status($bash_target) });
+    # Status before creating symlinks
+    my $before = capture(sub { do_status($bash_target) });
     like($before, qr/not linked/, 'Status shows "not linked" before');
     
-    # Link
-    _capture(sub { do_link($bash_target, { 'dry-run' => 0 }) });
+    # Apply
+    capture(sub { do_apply($bash_target, { 'dry-run' => 0 }) });
     
-    # Status after linking
-    my $after = _capture(sub { do_status($bash_target) });
+    # Status after creating symlinks
+    my $after = capture(sub { do_status($bash_target) });
     like($after, qr/->/, 'Status shows symlink arrow after');
 };
 
@@ -249,15 +238,15 @@ subtest 'Backup and restore cycle' => sub {
     my @targets = build_targets($config);
     my ($bash_target) = grep { $_->key eq 'bash' } @targets;
     
-    # Link (should create backup)
-    _capture(sub { do_link($bash_target, { 'dry-run' => 0 }) });
+    # Apply (should create backup)
+    capture(sub { do_apply($bash_target, { 'dry-run' => 0 }) });
     
     ok(-l $bashrc, '.bashrc is now a symlink');
     ok(-e "$bashrc.bak", 'Backup was created');
     is(_read_file("$bashrc.bak"), $original_content, 'Backup has original content');
     
-    # Unlink (should restore backup)
-    _capture(sub { do_unlink($bash_target, { 'dry-run' => 0 }) });
+    # Clean (should restore backup)
+    capture(sub { do_clean($bash_target, { 'dry-run' => 0 }) });
     
     ok(-e $bashrc, '.bashrc exists after unlink');
     ok(!-l $bashrc, '.bashrc is not a symlink');
@@ -280,14 +269,14 @@ subtest 'Filter with --only' => sub {
     is(scalar(@filtered), 1, 'Only one target after filter');
     is($filtered[0]->key, 'bash', 'Filtered target is bash');
     
-    # Link only bash
-    _capture(sub { do_link($filtered[0], { 'dry-run' => 0 }) });
+    # Apply only bash
+    capture(sub { do_apply($filtered[0], { 'dry-run' => 0 }) });
     
     my $bashrc = File::Spec->catfile($mock->{home}, '.bashrc');
     my $gitconfig = File::Spec->catfile($mock->{home}, '.gitconfig');
     
-    ok(-l $bashrc, 'bash files linked');
-    ok(!-e $gitconfig, 'git files NOT linked (filtered out)');
+    ok(-l $bashrc, 'bash files applied');
+    ok(!-e $gitconfig, 'git files NOT applied (filtered out)');
 };
 
 #=============================================================================
@@ -302,17 +291,17 @@ subtest 'Filter with --ignore' => sub {
     # Ignore bash
     my @filtered = filter_targets(\@targets, { ignore => ['bash', 'emacs', 'empty'] });
     
-    # Link remaining
+    # Apply remaining
     for my $target (@filtered) {
         next unless $target->is_valid;
-        _capture(sub { do_link($target, { 'dry-run' => 0 }) });
+        capture(sub { do_apply($target, { 'dry-run' => 0 }) });
     }
     
     my $bashrc = File::Spec->catfile($mock->{home}, '.bashrc');
     my $gitconfig = File::Spec->catfile($mock->{home}, '.gitconfig');
     
-    ok(!-e $bashrc, 'bash NOT linked (ignored)');
-    ok(-l $gitconfig, 'git linked');
+    ok(!-e $bashrc, 'bash NOT applied (ignored)');
+    ok(-l $gitconfig, 'git applied');
 };
 
 #=============================================================================
@@ -330,24 +319,24 @@ subtest 'Dry-run safety' => sub {
     my @targets = build_targets($config);
     my ($bash_target) = grep { $_->key eq 'bash' } @targets;
     
-    # Dry-run link
-    my $out1 = _capture(sub { do_link($bash_target, { 'dry-run' => 1 }) });
+    # Dry-run apply
+    my $out1 = capture(sub { do_apply($bash_target, { 'dry-run' => 1 }) });
     
     ok(-f $bashrc, '.bashrc still a regular file');
     ok(!-l $bashrc, '.bashrc NOT a symlink');
     ok(!-e "$bashrc.bak", 'No backup created');
     like($out1, qr/Would/, 'Output says "Would"');
     
-    # Actually link
-    _capture(sub { do_link($bash_target, { 'dry-run' => 0 }) });
+    # Actually apply
+    capture(sub { do_apply($bash_target, { 'dry-run' => 0 }) });
     ok(-l $bashrc, '.bashrc is now a symlink');
     
-    # Dry-run unlink
-    my $out2 = _capture(sub { do_unlink($bash_target, { 'dry-run' => 1 }) });
+    # Dry-run clean
+    my $out2 = capture(sub { do_clean($bash_target, { 'dry-run' => 1 }) });
     
-    ok(-l $bashrc, '.bashrc still a symlink after dry-run unlink');
+    ok(-l $bashrc, '.bashrc still a symlink after dry-run clean');
     ok(-e "$bashrc.bak", 'Backup still exists');
-    like($out2, qr/Would/, 'Unlink output says "Would"');
+    like($out2, qr/Would/, 'Clean output says "Would"');
 };
 
 #=============================================================================


### PR DESCRIPTION
- Simplified the makefile, removing unnecessary targets
- Renamed the following commands:
  - link -> apply
  - unlink -> clean
- Updated all references to old commands, and test documentation/comments