### PR TITLE
Feat: Reverse config

### DIFF
--- a/lib/Symlish/LinkItem.pm
+++ b/lib/Symlish/LinkItem.pm
@@ -8,8 +8,8 @@ use warnings;
 
 # new(%args) - Constructor for LinkItem.
 # Params (via %args):
-#   source - Absolute path to source file in dotfiles
-#   target - Absolute path to destination symlink location
+#   source - Absolute path to the file/directory the symlink will point AT.
+#   target - Absolute path where the symlink itself will be created.
 # Returns: Blessed LinkItem object
 sub new {
     my ($class, %args) = @_;
@@ -22,11 +22,11 @@ sub new {
     }, $class;
 }
 
-# Accessors - Read-only access to object properties
-# source() - Returns absolute path to source file in dotfiles
-# target() - Returns absolute path to symlink destination
-# backup() - Returns path to backup file (target + '.bak')
-# type()   - Returns 'file' or 'directory'
+# Accessors - Read-only access to object properties.
+# source() - Absolute path that the symlink points at
+# target() - Absolute path where the symlink lives (or will live)
+# backup() - Path of the saved-aside original at $target.bak
+# type()   - 'file' or 'directory', based on the source at construction time
 sub source { $_[0]->{source} }
 sub target { $_[0]->{target} }
 sub backup { $_[0]->{backup} }
@@ -99,7 +99,8 @@ sub restore_backup {
         or die "Failed to restore backup: $!";
 }
 
-# create_symlink() - Creates symlink from target to source.
+# create_symlink() - Creates a symlink at $self->target pointing to
+#   $self->source. Mirrors the syscall ordering: symlink(SRC, LINK).
 # Dies: If symlink creation fails
 sub create_symlink {
     my ($self) = @_;

--- a/lib/Symlish/LinkTarget.pm
+++ b/lib/Symlish/LinkTarget.pm
@@ -29,7 +29,7 @@ sub new {
     }, $class;
 
     # Find the first valid destination path
-    $self->_resolve_path($args{entry}{paths});
+    $self->_resolve_path($args{entry}{paths}, $args{config_dir});
 
     # If we found a path, expand the glob and build items
     if ($self->{path}) {
@@ -39,77 +39,91 @@ sub new {
     return $self;
 }
 
-# _resolve_path($paths_ref) - Finds first existing destination path.
-# Expands environment variables ($HOME, $APPDATA) and ~ in paths.
-# Sets $self->{path} to the first path that exists on the system.
+# _resolve_path($paths_ref, $config_dir) - Sets $self->{path} to the first
+# candidate that exists on the filesystem. Env vars and ~ are expanded first.
+# Absolute candidates are checked as-is. Relative candidates are anchored to 
+# $config_dir (NOT to the current working directory) so that resolution is
+# stable regardless of where symlish was invoked from.
 # Params:
-#   $paths_ref - Array ref of candidate destination paths
+#   $paths_ref  - Array ref of candidate destination paths (absolute or relative)
+#   $config_ref - Absolute path to the config directory, used as the base for
+#                 relative candidates
 sub _resolve_path {
-    my ($self, $paths_ref) = @_;
+    my ($self, $paths_ref, $config_dir) = @_;
 
     for my $candidate (@$paths_ref) {
-        # Expand environment variables ($HOME, $APPDATA, etc.)
-        my $expanded = $candidate;
-        $expanded =~ s/\$(\w+)/exists $ENV{$1} ? $ENV{$1} : ''/ge;
+        my $expanded = expand_path($candidate);
 
-        # Expand ~ to home directory
-        $expanded =~ s/^~/$ENV{HOME}/;
+        my $resolved = File::Spec->file_name_is_absolute($expanded)
+            ? $expanded
+            : File::Spec->catfile($config_dir, $expanded);
 
-        # Get absolute path and check if exists
-        my $abs = File::Spec->rel2abs($expanded);
-
-        if (-e $abs) {
-            $self->{path} = $abs;
+        if (-e $resolved) {
+            $self->{path} = $resolved;
             return;
         }
     }
 }
 
-# _build_items($config_dir, $target_pattern) - Expands glob and creates LinkItems.
-# Globs the target pattern to find source files, then creates LinkItem
-# objects mapping each source to its destination path.
+# _build_items($config_dir, $target_pattern) - Expands the glob and 
+# populates $self->{items}
+# Supports both forward configs (relative target, e.g. 'bash/*') and 
+# reverse config (absolute target, e.g. /etc/myapp/*). The destination 
+# layout differs between the two (see loop below)
 # Params:
-#   $config_dir     - Absolute path to dotfiles directory
-#   $target_pattern - Glob pattern (e.g., 'bash/**', 'vscode/*')
+#   $config_dir     - Absolute path to the config directory
+#   $target_pattern - Glob pattern, relative to $config_dir or absolute
 sub _build_items {
     my ($self, $config_dir, $target_pattern) = @_;
 
-    my $glob_pattern = File::Spec->catfile($config_dir, $target_pattern);
+    my $expanded = expand_path($target_pattern);
+    my $is_absolute = File::Spec->file_name_is_absolute($expanded);
 
-    # bsd_glob with GLOB_CSH handles most cases; we also explicitly glob for dotfiles
-    my @matches = bsd_glob($glob_pattern);
+    # Base pattern: an absolute pattern is used as-is; a relative pattern is
+    # anchored to $config_dir. Both branches use $expanded so env vars and ~
+    # are honoured consistently.
+    my $base_pattern = $is_absolute
+        ? $expanded
+        : File::Spec->catfile($config_dir, $expanded);
 
-    # If pattern doesn't explicitly start with a dot, try matching dotfiles
-    # by prepending a dot variant for the last component
-    if ($target_pattern =~ /\*/) {
-        # Replace * with .* in the last path component to match dotfiles
-        my $dot_pattern = $glob_pattern;
+    # bsd_glob's default doesn't match dotfiles (e.g. ~/.bashrc), so for any pattern
+    # containing a literal '*' we also glob a dot-augmented variant ('/*' -> '/.*')
+    # and rely on the basename filter below to drop '.' and '..'.
+    my @patterns = ($base_pattern);
+    if($target_pattern =~ /\*/) {
+        my $dot_pattern = $base_pattern;
         $dot_pattern =~ s{/\*}{/.*}g;
-        push @matches, bsd_glob($dot_pattern);
+        push @patterns, $dot_pattern;
     }
 
-    # Deduplicate
+    # Expand, drop '.' and '..', then deduplicate (preserving order)
     my %seen;
-    @matches = grep { !$seen{$_}++ } @matches;
+    my @sources = grep { !$seen{$_}++ }
+                    grep { basename($_) !~ /^\.\.?$/ }
+                    map  { bsd_glob($_) } @patterns;
 
-    for my $source (@matches) {
-        # Skip . and ..
-        next if basename($source) =~ /^\.\.?$/;
-
-        # Get relative path from config_dir
-        my $rel = File::Spec->abs2rel($source, $config_dir);
-
-        # Split the path and drop the first component (the target folder name)
-        my @parts = File::Spec->splitdir($rel);
-        shift @parts;
-
-        # Build destination path
-        my $dest = File::Spec->catfile($self->{path}, @parts);
+    # Forward config: 'bash/*' globs to e.g. '$config_dir/bash/.bashrc'.
+    #   We strip the top-level directory component ('bash') and preserve 
+    #   any remaining subtree under $self->{path}
+    # Reverse config: '/etc/myapp/*' globs to e.g. '/etc/myapp/foo.conf'.
+    #   There is no project-relative subtree to preserve, so we flatten
+    #   by basename: each source lands directly under $self->{path}.
+    for my $source (@sources) {
+        my $dest;
+        if($is_absolute) {
+            $dest = File::Spec->catfile($self->{path}, basename($source));
+        }
+        else {
+            my $rel = File::Spec->abs2rel($source, $config_dir);
+            my @parts = File::Spec->splitdir($rel);
+            shift @parts;
+            $dest = File::Spec->catfile($self->{path}, @parts);
+        }
 
         push @{ $self->{items} }, Symlish::LinkItem->new(
             source => $source,
             target => $dest,
-        );
+        )
     }
 }
 
@@ -129,11 +143,12 @@ sub conflict        { $_[0]->{conflict} }
 sub items           { @{ $_[0]->{items} } }
 sub is_valid        { defined $_[0]->{path} }
 
-# _to_bool($val, $default) - Converts YAML boolean values to Perl boolean.
-# Handles: 0, 1, 'true', 'false', '', undef
+# _to_bool($val, $default) - Converts an INI boolean string to 1 or 0.
+# Recognised as false: '0', 'false' (case-insensitive), ''.
+# Anything else is treated as true. Undef returns $default
 # Params:
-#   $val     - The value to convert
-#   $default - Default if $val is undefined
+#   $val     - The string value to convert, or undef
+#   $default - Value to return when $val is undef
 # Returns: 1 or 0
 sub _to_bool {
     my ($val, $default) = @_;
@@ -141,6 +156,35 @@ sub _to_bool {
     return $default unless defined $val;
     return 0 if $val eq '0' || $val =~ /^false$/i || $val eq '';
     return 1;
+}
+
+# expand_path($raw) - Expands shell-like path tokens.
+# Performs two substitutions:
+#   1. $VAR is replaced with $ENV{VAR}, or with empty string if unset.
+#   2. A leading '~' is replaced with user's home directory ($HOME on
+#      POSIX, failing back to $USERPROFILE on Windows where HOME is 
+#      usually unset), If neither is set, '~' is left untouched.
+# Notes: 
+#   1. Unset $VAR collapses to empty string, which can turn a path like
+#      '$APPDATA/Code/' into '/Code' on a system without APPDATA. Callers
+#      rely on the existence check in _resolve_path to discard such candidates.
+#   2. Windows-specific paths (e.g. %APPDATA%) are not supported. Symlish is 
+#      indented to be run from minGW or MSYS environments.
+# Params:
+#   $raw - Path string from config
+# Returns: Expanded path string
+sub expand_path {
+    my ($raw) = @_;
+
+    # Expand environment variables ($HOME, $APPDATA, etc.).
+    my $expanded = $raw;
+    $expanded =~ s/\$(\w+)/exists $ENV{$1} ? $ENV{$1} : ''/ge;
+
+    # Expand leading ~ to user's home directory
+    my $home = $ENV{HOME} // $ENV{USERPROFILE};
+    $expanded =~ s/^~/$home/ if defined $home;
+
+    return $expanded;
 }
 
 1;

--- a/t/00-config.t
+++ b/t/00-config.t
@@ -33,7 +33,7 @@ subtest 'Missing config file' => sub {
 #=============================================================================
 # Legacy config tests
 #=============================================================================
-# There test the pre-1.1.0 layout where the file is a flat list of 
+# These test the pre-1.1.0 layout where the file is a flat list of 
 # [entry] headers with no [[profile]] wrapper. Symlish wraps legacy config in
 # an implicit 'default' profile to ensure backwards compatibility.
 #=============================================================================

--- a/t/03-link-target.t
+++ b/t/03-link-target.t
@@ -119,11 +119,18 @@ subtest 'Environment variable expansion' => sub {
 #=============================================================================
 # Test: Tilde expansion
 #=============================================================================
+# Pin HOME (and USERPROFILE for the Windows fallback) to the tempdir so the
+# assertion below is deterministic regardless of the environment the test
+# is run in. Without this, an unset HOME on Winodws would compare undef vs 
+# whatever the fallback produced.
 subtest 'Tilde expansion' => sub {
     my $tempdir = tempdir(CLEANUP => 1);
     my $src_dir = File::Spec->catdir($tempdir, 'test');
     make_path($src_dir);
     _write_file(File::Spec->catfile($src_dir, 'file.txt'), 'test');
+
+    local $ENV{HOME}        = $tempdir;
+    local $ENV{USERPROFILE} = $tempdir;
     
     my $target = Symlish::LinkTarget->new(
         key => 'test',
@@ -134,7 +141,7 @@ subtest 'Tilde expansion' => sub {
         config_dir => $tempdir,
     );
     
-    is($target->path, $ENV{HOME}, 'Tilde expanded to HOME');
+    is($target->path, $tempdir, 'Tilde expanded to home directory');
 };
 
 #=============================================================================
@@ -232,6 +239,27 @@ subtest 'ignore flag' => sub {
 };
 
 #=============================================================================
+# Test: ignore-empty = false is honoured
+#=============================================================================
+subtest 'ignore-empty flag set to false' => sub {
+    my $tempdir = tempdir(CLEANUP => 1);
+    my $dest_dir = File::Spec->catdir($tempdir, 'dest');
+    make_path($dest_dir);
+    
+    my $target = Symlish::LinkTarget->new(
+        key => 'test',
+        entry => {
+            target          => 'test/*',
+            paths           => [$dest_dir],
+            'ignore-empty'  => 'false',
+        },
+        config_dir => $tempdir,
+    );
+    
+    ok(!$target->ignore_empty, 'ignore_empty is false when explicitly disabled');
+};
+
+#=============================================================================
 # Test: ignore-empty flag defaults to true
 #=============================================================================
 subtest 'ignore-empty flag defaults' => sub {
@@ -300,6 +328,166 @@ subtest 'Target path mapping' => sub {
         'Source path is correct');
     is($item->target, File::Spec->catfile($dest_dir, 'file.txt'), 
         'Target path strips source directory component');
+};
+
+#=============================================================================
+# Reverse config tests
+#=============================================================================
+# From 1.1.0, reverse config is supported, flipping the typical usage:
+# Source files live somewhere on the filesystem (e.g. /etc/something/*) and the
+# symlinks are created INSIDE a specified directory, "collecting" them 
+# in a central location. The 'paths' entry is then a subdirectory of $config_dir
+# rather than an absolute system location.
+#=============================================================================
+
+#=============================================================================
+# Test: Reverse config - absolute target, config-dir-relative path
+#=============================================================================
+subtest 'Reverse config: absolute target with single file' => sub {
+    my $tempdir = tempdir(CLEANUP => 1);
+
+    # External source: a file somewhere on the filesystem
+    my $external_dir = File::Spec->catdir($tempdir, 'external');
+    make_path($external_dir);
+    
+    my $source_file = File::Spec->catfile($external_dir, 'one.conf');
+    _write_file($source_file, 'content');
+
+    # Central location with a "collected" subdirectory to hold the symlinks
+    my $config_dir = File::Spec->catdir($tempdir, 'config_root');
+    my $collected  = File::Spec->catdir($config_dir, "collected");
+    make_path($collected);
+
+    my $target = Symlish::LinkTarget->new(
+        key => 'one',
+        entry => {
+            target => $source_file, # absolute path to a single file
+            paths  => [$collected],  # absolute dest for simplicity
+        },
+        config_dir => $config_dir,
+    );
+
+    ok($target->is_valid, 'is_valid for reverse-config target');
+    is($target->path, $collected, 'path resolved to the collected/ dir');
+
+    my @items = $target->items;
+    is(scalar @items, 1, 'single item built');
+    is($items[0]->source, $source_file, 'source is the absolute external path');
+    is($items[0]->target, File::Spec->catfile($collected, 'one.conf'), 
+        'target is collected/<basename>');
+};
+
+#=============================================================================
+# Test: Reverse config - absolute glob spanning multiple files
+#=============================================================================
+subtest 'Reverse config: absolute glob target' => sub {
+    my $tempdir = tempdir(CLEANUP => 1);
+
+    my $external_dir = File::Spec->catdir($tempdir, 'external');
+    make_path($external_dir);
+    _write_file(File::Spec->catfile($external_dir, 'a.conf'), 'a');
+    _write_file(File::Spec->catfile($external_dir, 'b.conf'), 'b');
+    _write_file(File::Spec->catfile($external_dir, 'c.conf'), 'c');
+
+    my $config_dir = File::Spec->catdir($tempdir, 'config_root');
+    my $collected  = File::Spec->catdir($config_dir, 'collected');
+    make_path($collected);
+
+    my $target = Symlish::LinkTarget->new(
+        key => 'glob',
+        entry => {
+            target => File::Spec->catfile($external_dir, '*'),
+            paths  => [$collected],
+        },
+        config_dir => $config_dir,
+    );
+
+    my @items = $target->items;
+    is(scalar @items, 3, 'three items built from glob');
+
+    my %sources = map { $_->source => 1} @items;
+    ok($sources{File::Spec->catfile($external_dir, 'a.conf')}, 'a.conf source');
+    ok($sources{File::Spec->catfile($external_dir, 'b.conf')}, 'b.conf source');
+    ok($sources{File::Spec->catfile($external_dir, 'c.conf')}, 'c.conf source');
+
+    # Destination should be flat under $collected (no preserved subtree)
+    my %dests = map { $_->target => 1} @items;
+    ok($dests{File::Spec->catfile($collected, 'a.conf')}, 'a.conf target');
+    ok($dests{File::Spec->catfile($collected, 'b.conf')}, 'b.conf target');
+    ok($dests{File::Spec->catfile($collected, 'c.conf')}, 'c.conf target');
+};
+
+#=============================================================================
+# Test: Reverse config - dotfile in absolute target
+#=============================================================================
+subtest 'Reverse config: dotfile included via absolute glob' => sub {
+    my $tempdir = tempdir(CLEANUP => 1);
+
+    my $external_dir = File::Spec->catdir($tempdir, 'external');
+    make_path($external_dir);
+
+    _write_file(File::Spec->catfile($external_dir, 'visible.txt'), 'v');
+    _write_file(File::Spec->catfile($external_dir, '.hidden'), 'h');
+
+    my $config_dir = File::Spec->catdir($tempdir, 'config_root');
+    my $collected  = File::Spec->catdir($config_dir, 'collected');
+    make_path($collected);
+
+    my $target = Symlish::LinkTarget->new(
+        key => 'mix',
+        entry => {
+            target => File::Spec->catfile($external_dir, '*'),
+            paths  => [$collected],
+        },
+        config_dir => $config_dir,
+    );
+
+    my @items = $target->items;
+    my %sources = map { $_->source => 1 } @items;
+
+    ok($sources{File::Spec->catfile($external_dir, 'visible.txt')}, 
+        'visible file included');
+    ok($sources{File::Spec->catfile($external_dir, '.hidden')}, 
+        'dotfile included via absolute glob');
+};
+
+#=============================================================================
+# Test: Reverse config - path relative to config_dir
+#=============================================================================
+subtest 'Reverse config - path relative to config_dir' => sub {
+    my $tempdir = tempdir(CLEANUP => 1);
+
+    my $external_dir = File::Spec->catdir($tempdir, 'external');
+    make_path($external_dir);
+    _write_file(File::Spec->catfile($external_dir, 'a.conf'), 'a');
+    _write_file(File::Spec->catfile($external_dir, 'b.conf'), 'b');
+
+    my $config_dir = File::Spec->catdir($tempdir, 'config_root');
+    my $collected  = File::Spec->catdir($config_dir, 'collected');
+    make_path($collected);
+
+    my $target = Symlish::LinkTarget->new(
+        key => 'rel',
+        entry => {
+            target => File::Spec->catfile($external_dir, '*'),
+            paths  => ['collected'], # relative, should resolve under $config_dir
+        },
+        config_dir => $config_dir,
+    );
+
+    ok($target->is_valid, 'is_valid for relative path resolved via config_dir');
+    is($target->path, $collected, 'relative path anchored to config_dir');
+
+    # Also test the full pipeline: items should reflect the resolved path,
+    # so destinations need to land under $collected, not under CWD/collected.
+    my @items = $target->items;
+    is(scalar @items, 2, 'two items materialised via the relative path');
+    
+    my %dests = map { $_->target => 1 } @items;
+    ok($dests{File::Spec->catfile($collected, 'a.conf')}, 
+        'a.conf destination under collected/');
+    ok($dests{File::Spec->catfile($collected, 'b.conf')}, 
+        'b.conf destination under collected/');
 };
 
 #=============================================================================


### PR DESCRIPTION
- Add support for "reverse config":
  - Unlike the regular use, where we specify files in a single dir tree (e.g. dotfiles repo), we can flip the config so that files from the filesystem are "collected" to a central location.
  - The config [entry]'s 'target' and 'paths' fields now accept absolute and relative paths. Relative paths are relative to the directory where the config exists, not CWD